### PR TITLE
switch to azure queues and enable local ssh keys 

### DIFF
--- a/crates/kr/Cargo.toml
+++ b/crates/kr/Cargo.toml
@@ -44,7 +44,15 @@ ansi_term = "0.12.1"
 directories = "3.0.2"
 dirs = "3.0.2"
 serde-xml-rs = "0.5.0"
-
+urlencoding = "2.1.0"
+nix = "0.22.1"
+openssl = "0.10"
+bitflags = "1"
+ecdsa = "0.13.4"
+ring = "0.16.20"
+untrusted = "0.9.0"
+pem = "1.0.2"
+osshkeys = "0.6.0"
 [target.'cfg(target_os="macos")'.dependencies]
 mac-notification-sys = "0.3.0"
 

--- a/crates/kr/src/prompt.rs
+++ b/crates/kr/src/prompt.rs
@@ -1,0 +1,78 @@
+//! GUI password prompt using pinentry
+use std::cmp;
+use std::io::prelude::*;
+use std::io::BufReader;
+use std::process::{Command, Stdio};
+
+pub struct PasswordPrompt {
+    key_name: String,
+}
+
+impl PasswordPrompt {
+    pub fn new(key_name: String) -> Self {
+        PasswordPrompt { key_name: key_name }
+    }
+
+    /// Invokes the password prompt and puts the entered password into `password_buffer`.
+    ///
+    /// Returns the number of bytes input into the buffer.
+    pub fn invoke(&self, password_buffer: &mut [u8]) -> usize {
+        #[cfg(target_os = "macos")]
+        let commmand_str = "pinentry-mac";
+
+        #[cfg(target_os = "linux")]
+        let commmand_str = "pinentry";
+
+        let mut pinentry = Command::new(commmand_str)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("pinentry command failed to start");
+
+        // Configure pinentry
+        let pincmd = pinentry.stdin.take();
+
+        match pincmd {
+            Some(mut pincmd) => {
+                writeln!(pincmd, "SETTITLE Unlock SSH key").expect("failed to write to pinentry");
+                writeln!(pincmd, "SETPROMPT Password:").expect("failed to write to pinentry");
+                writeln!(
+                    pincmd,
+                    "SETDESC Enter the password for unlocking the SSH key '{}'",
+                    self.key_name
+                )
+                .expect("failed to write to pinentry");
+                writeln!(pincmd, "GETPIN").expect("failed to write to pinentry");
+
+                let message = pinentry.stdout.take();
+
+                match message {
+                    Some(message) => {
+                        // Read until we get an "ERR" or "D" line
+                        let out = BufReader::new(message);
+                        for line in out.lines() {
+                            let line = line.expect("failed to read line from pinentry");
+                            if line.starts_with("ERR ") {
+                                pinentry.kill().expect("failed to kill pinentry");
+                                return 0; // Abort!
+                            } else if line.starts_with("D ") {
+                                let bytes = &line.as_bytes()[2..];
+                                for (byte, target) in bytes.iter().zip(password_buffer.iter_mut()) {
+                                    *target = *byte;
+                                }
+
+                                pinentry.kill().expect("failed to kill pinentry");
+                                return cmp::min(bytes.len(), password_buffer.len());
+                            }
+                        }
+                    }
+                    None => return 0,
+                }
+            }
+            None => return 0,
+        }
+
+        pinentry.kill().expect("failed to kill pinentry");
+        return 0;
+    }
+}

--- a/crates/kr/src/protocol.rs
+++ b/crates/kr/src/protocol.rs
@@ -8,6 +8,12 @@ pub const PROTOCOL_VERSION: &'static str = "3.0.0";
 
 base64_serde_type!(Base64Format, STANDARD);
 
+bitflags! {
+    pub struct SignFlags: u32 {
+        const SSH_AGENT_RSA_SHA2_256 = 2;
+        const SSH_AGENT_RSA_SHA2_512 = 4;
+    }
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Base64Buffer(#[serde(with = "Base64Format")] pub Vec<u8>);

--- a/crates/kr/src/setup.rs
+++ b/crates/kr/src/setup.rs
@@ -14,16 +14,19 @@ pub async fn run(args: SetupArgs) -> Result<(), Error> {
 
 /// print out config changes
 pub fn print_config() -> Result<(), Error> {
-    eprintln!(
+    println!(
         "== SSH Config Additions ==\n{}\n",
         create_ssh_config_stanza()?
     ); //TODO:ssh config
-    eprintln!("==  Background Service  ==\n{}\n", Daemon::new()?.render()?);
+    println!("==  Background Service  ==\n{}\n", Daemon::new()?.render()?);
     Ok(())
 }
 
 const BEGIN_CONFIG_STANZA: &'static str = "# Begin Akamai MFA SSH Config";
 const END_CONFIG_STANZA: &'static str = "# End Akamai MFA SSH Config";
+
+const BEGIN_KR_STANZA: &'static str = "# Added by Krypton";
+const KR_PROXY_COMMAND_STANZA: &'static str = "krssh %h %p";
 
 fn create_ssh_config_stanza() -> Result<String, Error> {
     let agent_socket_path = crate::create_home_path()?
@@ -62,6 +65,7 @@ pub async fn update_ssh_config(custom_path: Option<String>) -> Result<(), Error>
 
     // clear any existing config by us
     let mut lines: Vec<&str> = ssh_config.split("\n").collect();
+ 
     let start = lines
         .iter_mut()
         .position(|s| s.as_bytes() == BEGIN_CONFIG_STANZA.as_bytes());
@@ -69,14 +73,29 @@ pub async fn update_ssh_config(custom_path: Option<String>) -> Result<(), Error>
         .iter_mut()
         .position(|s| s.as_bytes() == END_CONFIG_STANZA.as_bytes());
 
-    let mut clean_config = match (start, end) {
+        let clean_akr_config_lines = match (start, end) {
         (Some(start), Some(end)) => vec![&lines[..start], &lines[(end + 1)..]]
             .concat()
             .join("\n"),
         _ => lines.join("\n"),
     };
 
-    clean_config.push_str(&create_ssh_config_stanza()?);
+    // clean up old kr stanza if any 
+    let mut lines_updated: Vec<&str> = clean_akr_config_lines.split("\n").collect();
+    let kr_start = lines_updated
+        .iter_mut()
+        .position(|s| s.as_bytes() == BEGIN_KR_STANZA.as_bytes());
+    let kr_end = lines_updated
+        .iter_mut()
+        .position(|s| s.contains(KR_PROXY_COMMAND_STANZA));
 
+    let mut clean_config = match (kr_start, kr_end) {
+        (Some(kr_start), Some(kr_end)) => vec![&lines_updated[..kr_start], &lines_updated[(kr_end + 1)..]]
+            .concat()
+            .join("\n"),
+        _ => lines_updated.join("\n"),
+    };
+
+    clean_config.push_str(&create_ssh_config_stanza()?);
     Ok(std::fs::write(&path, clean_config)?)
 }

--- a/crates/kr/src/ssh_agent.rs
+++ b/crates/kr/src/ssh_agent.rs
@@ -1,6 +1,7 @@
 use crate::client::Client;
+use crate::prompt::PasswordPrompt;
 use crate::protocol::{AuthenticateRequest, AuthenticateResponse, Base64Buffer, RequestBody};
-use crate::ssh_format::SshWirePublicKey;
+use crate::ssh_format::{SshKey, SshWirePublicKey};
 use crate::{
     error::*,
     util::{read_data, read_string},
@@ -10,11 +11,15 @@ use async_trait::async_trait;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use eagre_asn1::der::DER;
 use eagre_asn1::der_sequence;
+use osshkeys::PrivateParts;
 use ssh_agent::error::HandleResult;
 use ssh_agent::Identity;
 use ssh_agent::Response;
 use ssh_agent::SSHAgentHandler;
 use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::Path;
 use std::{
     io::{Cursor, Write},
     vec,
@@ -35,6 +40,7 @@ eagre_asn1::der_sequence! {
 pub struct Agent {
     pub client: Client,
     identities: HashMap<SshWirePublicKey, SshFido2KeyPairHandle>,
+    ssh_keys: Vec<SshKey>,
 }
 
 impl Agent {
@@ -42,89 +48,75 @@ impl Agent {
         Agent {
             client,
             identities: HashMap::new(),
+            ssh_keys: Vec::new(),
         }
     }
-}
 
-#[async_trait]
-impl SSHAgentHandler for Agent {
-    async fn identities(&mut self) -> HandleResult<Response> {
-        let ids = StoredIdentity::load_from_disk()?.key_pair_handles;
-        self.identities = ids
-            .into_iter()
-            .map(|kp| Ok((kp.fmt_public_key()?, kp)))
-            .collect::<Result<Vec<_>, Error>>()?
-            .into_iter()
-            .collect();
+    pub fn preload_user_keys_from_dir<P: AsRef<Path>>(&mut self, key_dir: P) {
+        let key_dir = key_dir.as_ref();
+        let key_count_pre = self.ssh_keys.len();
 
-        let ids = self
-            .identities
-            .iter()
-            .map(|(pubkey, kp)| {
-                Ok(Identity {
-                    key_comment: kp.application.clone(),
-                    key_blob: pubkey.clone(),
-                })
-            })
-            .collect::<Result<Vec<Identity>, Error>>()
-            .map(Response::Identities)?;
-
-        Ok(ids)
-    }
-
-    async fn add_identity(
-        &mut self,
-        key_type: String,
-        key_blob: Vec<u8>,
-    ) -> HandleResult<Response> {
-        if key_type.as_str() != SshFido2KeyPairHandle::TYPE_ID {
-            eprintln!("add error: not a fido2 ssh keypair");
-            return Ok(Response::Success);
-        }
-        /*
-           string		curve name
-           ec_point	Q
-           string		application (user-specified, but typically "ssh:")
-           uint8		flags
-           string		key_handle
-           string		reserved
-        */
-        let mut cursor = Cursor::new(key_blob);
-        let _curve_name = read_string(&mut cursor)?;
-        let public_key = read_data(&mut cursor)?;
-        let application = read_string(&mut cursor)?;
-        let flags = cursor.read_u8()?;
-        let key_handle = read_data(&mut cursor)?;
-
-        let identity = SshFido2KeyPairHandle {
-            application,
-            key_handle,
-            public_key,
-            flags,
+        let read_dir = match fs::read_dir(key_dir) {
+            Ok(rd) => rd,
+            Err(e) => {
+                eprintln!("couldn't read key directory {}: {}", key_dir.display(), e);
+                return;
+            }
         };
-        self.identities.insert(identity.fmt_public_key()?, identity);
 
-        Ok(Response::Success)
+        for entry in read_dir {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(e) => {
+                    eprintln!("couldn't read dir entry: {}", e);
+                    continue;
+                }
+            };
+
+            let path = entry.path();
+
+            // Find all `.pub` files in the directory
+            if path.extension() == Some(OsStr::new("pub")) {
+                // Only preload if the corresponding non-pub file exists
+                let priv_path = path.with_extension("");
+                match priv_path.metadata() {
+                    Ok(_) => match SshKey::from_paths(&path, priv_path) {
+                        Ok(key) => {
+                            println!(
+                                "successfully preloaded public key '{}' from {}",
+                                key.comment(),
+                                path.display()
+                            );
+                            self.ssh_keys.push(key);
+                        }
+                        Err(e) => {
+                            eprintln!("couldn't preload {}: {}", path.display(), e);
+                        }
+                    },
+                    Err(e) => {
+                        eprintln!(
+                            "{} has no associated private key file ({})",
+                            path.display(),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        println!(
+            "preloaded {} keys from {}",
+            self.ssh_keys.len() - key_count_pre,
+            key_dir.display()
+        );
     }
 
-    async fn sign_request(
+    async fn sign_fido2(
         &mut self,
         pubkey: Vec<u8>,
         data: Vec<u8>,
         _flags: u32,
     ) -> HandleResult<Response> {
-        /* data:
-         Packet Format (SSH_MSG_USERAUTH_REQUEST):
-         string    session identifier
-         byte      SSH_MSG_USERAUTH_REQUEST
-         string    user name
-         string    service name
-         string    "publickey"
-         boolean   TRUE
-         string    public key algorithm name
-         string    public key to be used for authentication
-        */
-
         // try to find the matching key handle
         let id = self
             .identities
@@ -132,7 +124,6 @@ impl SSHAgentHandler for Agent {
             .filter(|(pk, _)| pk.as_slice() == pubkey.as_slice())
             .next()
             .map(|id| id.1);
-
         let rp_id = if let Some(ref id) = &id {
             id.application.clone()
         } else {
@@ -203,6 +194,262 @@ impl SSHAgentHandler for Agent {
         data.write_u32::<BigEndian>(resp.counter)?;
 
         Ok(Response::SignResponse { signature: data })
+    }
+
+    async fn sign_rsa(
+        &mut self,
+        pubkey: Vec<u8>,
+        data: Vec<u8>,
+        flags: u32,
+        pubkey_type: String,
+    ) -> HandleResult<Response> {
+        let key = self
+            .ssh_keys
+            .iter_mut()
+            .find(|key| key.pub_key_blob() == pubkey);
+        match key {
+            Some(key) => {
+                let comment = key.comment().to_string();
+                let (signature, algo) = {
+                    let (priv_key, _ecdsa_key_pair) = match key.unlock_with(
+                        |buf| Ok(PasswordPrompt::new(comment).invoke(buf)),
+                        pubkey_type,
+                    ) {
+                        Ok(p) => p,
+                        Err(_e) => {
+                            return Ok(Response::Failure);
+                        }
+                    };
+
+                    match priv_key.sign_rsa(&data, &flags) {
+                        Ok((signature, algo)) => (signature, algo),
+                        Err(_e) => {
+                            return Ok(Response::Failure);
+                        }
+                    }
+                };
+
+                Ok(Response::SignResponse2 {
+                    algo_name: algo.to_string(),
+                    signature,
+                })
+            }
+            None => Ok(Response::Failure),
+        }
+    }
+
+    async fn sign_ecdsa(
+        &mut self,
+        pubkey: Vec<u8>,
+        data: Vec<u8>,
+        flags: u32,
+        pubkey_type: String,
+    ) -> HandleResult<Response> {
+        let key = self
+            .ssh_keys
+            .iter_mut()
+            .find(|key| key.pub_key_blob() == pubkey);
+        match key {
+            Some(key) => {
+                let comment = key.comment().to_string();
+                let signature = {
+                    let (priv_key, ecdsa_key_pair) = match key.unlock_with(
+                        |buf| Ok(PasswordPrompt::new(comment).invoke(buf)),
+                        pubkey_type.clone(),
+                    ) {
+                        Ok(p) => p,
+                        Err(_e) => {
+                            return Ok(Response::Failure);
+                        }
+                    };
+
+                    match priv_key.sign_ecdsa(&data, &flags, ecdsa_key_pair) {
+                        Ok(signature) => signature,
+                        Err(_e) => {
+                            return Ok(Response::Failure);
+                        }
+                    }
+                };
+
+                let asn1_sig = ECDSASign::der_from_bytes(signature)?;
+                let mut signature: Vec<u8> = Vec::new();
+
+                signature.write_u32::<BigEndian>(asn1_sig.r.len() as u32)?;
+                signature.write_all(asn1_sig.r.as_slice())?;
+
+                signature.write_u32::<BigEndian>(asn1_sig.s.len() as u32)?;
+                signature.write_all(asn1_sig.s.as_slice())?;
+
+                Ok(Response::SignResponse2 {
+                    algo_name: pubkey_type,
+                    signature,
+                })
+            }
+            None => Ok(Response::Failure),
+        }
+    }
+
+    async fn sign_ed25519(
+        &mut self,
+        pubkey: Vec<u8>,
+        data: Vec<u8>,
+        _flags: u32,
+        pubkey_type: String,
+    ) -> HandleResult<Response> {
+        let key = self
+            .ssh_keys
+            .iter_mut()
+            .find(|key| key.pub_key_blob() == pubkey);
+        match key {
+            Some(key) => match &key.keypair {
+                Some(keypair) => {
+                    let signature = keypair.sign(&data.as_slice()).unwrap();
+
+                    Ok(Response::SignResponse2 {
+                        algo_name: pubkey_type,
+                        signature,
+                    })
+                }
+                None => {
+                    let keypair = key.unlock_ed25519_key()?;
+
+                    match keypair {
+                        Some(kp) => {
+                            let signature = kp.sign(&data.as_slice()).unwrap();
+
+                            Ok(Response::SignResponse2 {
+                                algo_name: pubkey_type,
+                                signature,
+                            })
+                        }
+                        None => {
+                            return Ok(Response::Failure);
+                        }
+                    }
+                }
+            },
+            None => Ok(Response::Failure),
+        }
+    }
+}
+
+#[async_trait]
+impl SSHAgentHandler for Agent {
+    async fn identities(&mut self) -> HandleResult<Response> {
+        let ids = StoredIdentity::load_from_disk()?.key_pair_handles;
+        self.identities = ids
+            .into_iter()
+            .map(|kp| Ok((kp.fmt_public_key()?, kp)))
+            .collect::<Result<Vec<_>, Error>>()?
+            .into_iter()
+            .collect();
+
+        let mut identities = self
+            .identities
+            .iter()
+            .map(|(pubkey, kp)| {
+                Ok(Identity {
+                    key_comment: kp.application.clone(),
+                    key_blob: pubkey.clone(),
+                })
+            })
+            .collect::<Result<Vec<Identity>, Error>>()?;
+
+        let keys = self
+            .ssh_keys
+            .iter()
+            .map(|key| {
+                Ok(Identity {
+                    key_comment: key.comment().to_string(),
+                    key_blob: key.pub_key_blob().to_vec(),
+                })
+            })
+            .collect::<Result<Vec<Identity>, Error>>()?;
+
+        // push keys to ids
+        identities.extend(keys);
+
+        let ids = identities
+            .iter()
+            .map(|id| {
+                Ok(Identity {
+                    key_comment: id.key_comment.clone(),
+                    key_blob: id.key_blob.clone(),
+                })
+            })
+            .collect::<Result<Vec<Identity>, Error>>()
+            .map(Response::Identities)?;
+
+        Ok(ids)
+    }
+
+    async fn add_identity(
+        &mut self,
+        key_type: String,
+        key_blob: Vec<u8>,
+    ) -> HandleResult<Response> {
+        if key_type.as_str() != SshFido2KeyPairHandle::TYPE_ID {
+            eprintln!("add error: not a fido2 ssh keypair");
+            return Ok(Response::Success);
+        }
+        /*
+           string		curve name
+           ec_point	Q
+           string		application (user-specified, but typically "ssh:")
+           uint8		flags
+           string		key_handle
+           string		reserved
+        */
+        let mut cursor = Cursor::new(key_blob);
+        let _curve_name = read_string(&mut cursor)?;
+        let public_key = read_data(&mut cursor)?;
+        let application = read_string(&mut cursor)?;
+        let flags = cursor.read_u8()?;
+        let key_handle = read_data(&mut cursor)?;
+
+        let identity = SshFido2KeyPairHandle {
+            application,
+            key_handle,
+            public_key,
+            flags,
+        };
+        self.identities.insert(identity.fmt_public_key()?, identity);
+
+        Ok(Response::Success)
+    }
+
+    async fn sign_request(
+        &mut self,
+        pubkey: Vec<u8>,
+        data: Vec<u8>,
+        flags: u32,
+    ) -> HandleResult<Response> {
+        /* data:
+         Packet Format (SSH_MSG_USERAUTH_REQUEST):
+         string    session identifier
+         byte      SSH_MSG_USERAUTH_REQUEST
+         string    user name
+         string    service name
+         string    "publickey"
+         boolean   TRUE
+         string    public key algorithm name
+         string    public key to be used for authentication
+        */
+
+        let mut cursor = Cursor::new(pubkey.clone());
+        let pubkey_type = read_string(&mut cursor)?;
+
+        if pubkey_type == "sk-ecdsa-sha2-nistp256@openssh.com".to_string() {
+            self.sign_fido2(pubkey, data, flags).await
+        } else if pubkey_type.contains("ssh-rsa") {
+            self.sign_rsa(pubkey, data, flags, pubkey_type).await
+        } else if pubkey_type.contains("ecdsa") {
+            self.sign_ecdsa(pubkey, data, flags, pubkey_type).await
+        } else if pubkey_type.contains("ed25519") {
+            self.sign_ed25519(pubkey, data, flags, pubkey_type).await
+        } else {
+            Ok(Response::Failure)
+        }
     }
 }
 

--- a/crates/kr/templates/linux/systemd.service
+++ b/crates/kr/templates/linux/systemd.service
@@ -4,6 +4,7 @@ Description={{bin_name}}
 [Service]
 ExecStart={{bin_path}} start
 Restart=on-failure
+User={{current_user}}
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
This PR covers two features
1. enable local RSA, ECDSA and ED25519 keys to work with akr. 
3. switch to azure queues.

Feature 1 makes sure that if the user has any local ssh keys that he/she wants to work with akr, they can simple load the keys under ~/.ssh and akr will load those in the agent on startup. It supports RSA, ECDSA and ED25519 keys at the moment. 