### PR TITLE
Fix CI and remove CentOS 7 builds

### DIFF
--- a/.github/workflows/brew_bottle.yml
+++ b/.github/workflows/brew_bottle.yml
@@ -14,14 +14,18 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1.0.7
+      - name: Get Rust toolchain channel
+        run: |
+          echo "RUST_CHANNEL=$(sed -nrE 's/^channel = "(.*)"$/\1/p' "$GITHUB_WORKSPACE"/rust-toolchain.toml)" >> $GITHUB_ENV
+
+      - name: Install Rust ${{ env.RUST_CHANNEL }}
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          toolchain: ${{ env.RUST_CHANNEL }}
+          components: cargo
 
       - name: bottle
         run: ./brew_bottle.sh ${{ github.event.inputs.versionString }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,6 @@ jobs:
     strategy:
       matrix:
         image:
-          - "centos:7"
           - "alvistack/centos-9-stream"
     runs-on: ubuntu-22.04
     container:
@@ -112,10 +111,6 @@ jobs:
       - name: Remove all symbol and relocation information
         run: strip -s target/release/akr
 
-      - name: Set compress type for CentOS 7
-        if: matrix.image == 'centos:7'
-        run: echo "CENTOS_BUILD_FLAGS=--payload-compress=gzip" >> $GITHUB_ENV
-
       - name: Add dist to release
         run: dist=$(rpm --eval %{?dist}); sed -i -e 's/release = "\(.*\)"/release = "\1'$dist'"/g' Cargo.toml
 
@@ -133,5 +128,5 @@ jobs:
       - name: Upload RPM
         uses: actions/upload-artifact@v4.6.0
         with:
-          name: akr-${{ matrix.image == 'centos:7' && 'centos-7' || 'centos-9-stream' }}
+          name: akr-${{ matrix.image == 'alvistack/centos-9-stream' && 'centos-9-stream' || 'unknown' }}
           path: target/generate-rpm/*.rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,23 +22,21 @@ jobs:
       - name: Install common libs
         run: |
           sudo apt-get update
-          sudo apt-get install pkg-config libssl-dev lintian  libpqxx-dev libxmlsec1-dev libclang-9-dev
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: ${{ matrix.target }}
+          sudo apt-get install pkg-config libssl-dev lintian  libpqxx-dev libxmlsec1-dev libclang-dev
 
       - name: Checkout
         uses: actions/checkout@v4.2.2
 
-      - name: Restore cache
-        uses: Swatinem/rust-cache@v2.7.7
+      - name: Get Rust toolchain channel
+        run: |
+          echo "RUST_CHANNEL=$(sed -nrE 's/^channel = "(.*)"$/\1/p' "$GITHUB_WORKSPACE"/rust-toolchain.toml)" >> $GITHUB_ENV
+
+      - name: Install Rust ${{ env.RUST_CHANNEL }}
+        uses: dtolnay/rust-toolchain@master
         with:
-          key: ${{ matrix.target }}
+          toolchain: ${{ env.RUST_CHANNEL }}
+          targets: ${{ matrix.target }}
+          components: cargo
 
       - name: Install Cargo Deb
         uses: actions-rs/cargo@v1.0.3
@@ -83,20 +81,18 @@ jobs:
           yum update -y && yum install -y epel-release && yum install -y gcc make cmake3 gcc-c++ openssl-devel gzip rpmlint
           ln -s /usr/bin/cmake3 /usr/bin/cmake
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
       - name: Checkout
         uses: actions/checkout@v4.2.2
 
-      - name: Restore cache
-        uses: Swatinem/rust-cache@v2.7.7
+      - name: Get Rust toolchain channel
+        run: |
+          echo "RUST_CHANNEL=$(sed -nrE 's/^channel = "(.*)"$/\1/p' "$GITHUB_WORKSPACE"/rust-toolchain.toml)" >> $GITHUB_ENV
+
+      - name: Install Rust ${{ env.RUST_CHANNEL }}
+        uses: dtolnay/rust-toolchain@master
         with:
-          key: ${{ matrix.image }}
+          toolchain: ${{ env.RUST_CHANNEL }}
+          components: cargo
 
       - name: Delete previous RPM
         run: rm -f target/generate-rpm/*.rpm

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -23,23 +23,21 @@ jobs:
       - name: Install common libs
         run: |
           sudo apt-get update
-          sudo apt-get install pkg-config libssl-dev lintian  libpqxx-dev libxmlsec1-dev libclang-9-dev
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: ${{ matrix.target }}
+          sudo apt-get install pkg-config libssl-dev lintian  libpqxx-dev libxmlsec1-dev libclang-dev
 
       - name: Checkout
         uses: actions/checkout@v4.2.2
 
-      - name: Restore cache
-        uses: Swatinem/rust-cache@v2.7.7
+      - name: Get Rust toolchain channel
+        run: |
+          echo "RUST_CHANNEL=$(sed -nrE 's/^channel = "(.*)"$/\1/p' "$GITHUB_WORKSPACE"/rust-toolchain.toml)" >> $GITHUB_ENV
+
+      - name: Install Rust ${{ env.RUST_CHANNEL }}
+        uses: dtolnay/rust-toolchain@master
         with:
-          key: ${{ matrix.target }}
+          toolchain: ${{ env.RUST_CHANNEL }}
+          targets: ${{ matrix.target }}
+          components: cargo
 
       - name: Install Cargo Deb
         uses: actions-rs/cargo@v1.0.3
@@ -90,20 +88,18 @@ jobs:
           yum update -y && yum install -y epel-release && yum install -y gcc make cmake3 gcc-c++ openssl-devel gzip rpmlint
           ln -s /usr/bin/cmake3 /usr/bin/cmake
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
       - name: Checkout
         uses: actions/checkout@v4.2.2
 
-      - name: Restore cache
-        uses: Swatinem/rust-cache@v2.7.7
+      - name: Get Rust toolchain channel
+        run: |
+          echo "RUST_CHANNEL=$(sed -nrE 's/^channel = "(.*)"$/\1/p' "$GITHUB_WORKSPACE"/rust-toolchain.toml)" >> $GITHUB_ENV
+
+      - name: Install Rust ${{ env.RUST_CHANNEL }}
+        uses: dtolnay/rust-toolchain@master
         with:
-          key: ${{ matrix.image }}
+          toolchain: ${{ env.RUST_CHANNEL }}
+          components: cargo
 
       - name: Delete previous RPM
         run: rm -f target/generate-rpm/*.rpm

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -69,6 +69,7 @@ jobs:
           asset_path: target/${{ matrix.target }}/debian/akr_${{ github.event.inputs.versionString }}_amd64.deb
           asset_name: "akr_${{github.event.inputs.versionString}}_amd64.deb"
           asset_content_type: application/vnd.debian.binary-package
+
   rpm:
     name: RPM package
     env:
@@ -76,7 +77,6 @@ jobs:
     strategy:
       matrix:
         image:
-          - "centos:7"
           - "alvistack/centos-9-stream"
     runs-on: ubuntu-22.04
     container:
@@ -90,10 +90,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4.2.2
-
-      - name: Get Rust toolchain channel
-        run: |
-          echo "RUST_CHANNEL=$(sed -nrE 's/^channel = "(.*)"$/\1/p' "$GITHUB_WORKSPACE"/rust-toolchain.toml)" >> $GITHUB_ENV
 
       - name: Install Rust ${{ env.RUST_CHANNEL }}
         uses: dtolnay/rust-toolchain@master
@@ -118,10 +114,6 @@ jobs:
 
       - name: Remove all symbol and relocation information
         run: strip -s target/release/akr
-
-      - name: Set compress type for CentOS 7
-        if: matrix.image == 'centos:7'
-        run: echo "CENTOS_BUILD_FLAGS=--payload-compress=gzip" >> $GITHUB_ENV
 
       - name: Add dist to release
         run: dist=$(rpm --eval %{?dist}); sed -i -e 's/release = "\(.*\)"/release = "\1'$dist'"/g' Cargo.toml
@@ -148,5 +140,5 @@ jobs:
         with:
           upload_url: ${{ steps.fetch-latest-release.outputs.upload_url }}
           asset_path: target/generate-rpm/akr-${{ github.event.inputs.versionString}}-1.x86_64.rpm
-          asset_name: "akr_${{github.event.inputs.versionString}}-${{ matrix.image == 'centos:7' && 'centos-7' || 'centos-9-stream' }}.rpm"
+          asset_name: "akr_${{github.event.inputs.versionString}}-${{ matrix.image == 'alvistack/centos-9-stream' && 'centos-9-stream' || 'unknown' }}.rpm"
           asset_content_type: application/octet-stream

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ sudo yum -y install akr
 sudo yum -y install pinentry-gtk
 ```
 
-
 ### CentOS-9/RHEL-9
 
 ```sh

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,8 +2,3 @@
 [toolchain]
 channel = "stable"
 components = ["rustfmt", "clippy"]
-
-# TODO Use with actions-rs/toolchain:
-#  Support new TOML format for rust-toolchain
-#  https://github.com/actions-rs/toolchain/issues/126
-#  https://github.com/actions-rs/toolchain/pull/166


### PR DESCRIPTION
Fixes #71 

CentOS 7 is no longer supported and the build fails during `action/checkout`. Users can still install akr on CentOS 7 but they won't receive newer versions of akr.