### PR TITLE
Add arm64 support for Linux packages and Homebrew bottles

### DIFF
--- a/.github/workflows/brew_bottle.yml
+++ b/.github/workflows/brew_bottle.yml
@@ -34,11 +34,13 @@ jobs:
 
           mkdir -p /tmp/akr/${VERSION}/bin
           cp ./target/release/akr /tmp/akr/${VERSION}/bin/
-          tar -czf akr-${VERSION}.big_sur.bottle.tar.gz -C /tmp akr
-          cp akr-${VERSION}.big_sur.bottle.tar.gz akr-${VERSION}.catalina.bottle.tar.gz
-      
+          tar -czf akr-${VERSION}.arm64_big_sur.bottle.tar.gz -C /tmp akr
+          for codename in arm64_monterey arm64_ventura arm64_sonoma arm64_sequoia; do
+            cp akr-${VERSION}.arm64_big_sur.bottle.tar.gz akr-${VERSION}.${codename}.bottle.tar.gz
+          done
+
           ls *.bottle.tar.gz
-      
+
           # clean up
           rm -rf /tmp/akr
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,29 @@ jobs:
         include:
           - image: "ubuntu:22.04"
             platform: "ubuntu22"
+            arch: "amd64"
+            runner: "ubuntu-24.04"
+          - image: "ubuntu:22.04"
+            platform: "ubuntu22"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
           - image: "ubuntu:24.04"
             platform: "ubuntu24"
+            arch: "amd64"
+            runner: "ubuntu-24.04"
+          - image: "ubuntu:24.04"
+            platform: "ubuntu24"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
           - image: "ubuntu:26.04"
             platform: "ubuntu26"
-    runs-on: ubuntu-24.04
+            arch: "amd64"
+            runner: "ubuntu-24.04"
+          - image: "ubuntu:26.04"
+            platform: "ubuntu26"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
+    runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
 
@@ -58,7 +76,7 @@ jobs:
       - name: Upload asset
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: akr_${{ matrix.platform }}_amd64.deb
+          name: akr_${{ matrix.platform }}_${{ matrix.arch }}.deb
           path: akr.deb
 
   rhel:
@@ -72,13 +90,34 @@ jobs:
           - image: "rockylinux/rockylinux:8"
             platform: "rhel8"
             repo: "powertools"
+            arch: "x86_64"
+            runner: "ubuntu-24.04"
+          - image: "rockylinux/rockylinux:8"
+            platform: "rhel8"
+            repo: "powertools"
+            arch: "aarch64"
+            runner: "ubuntu-24.04-arm"
           - image: "rockylinux/rockylinux:9"
             platform: "rhel9"
             repo: "crb"
+            arch: "x86_64"
+            runner: "ubuntu-24.04"
+          - image: "rockylinux/rockylinux:9"
+            platform: "rhel9"
+            repo: "crb"
+            arch: "aarch64"
+            runner: "ubuntu-24.04-arm"
           - image: "rockylinux/rockylinux:10"
             platform: "rhel10"
             repo: "crb"
-    runs-on: ubuntu-24.04
+            arch: "x86_64"
+            runner: "ubuntu-24.04"
+          - image: "rockylinux/rockylinux:10"
+            platform: "rhel10"
+            repo: "crb"
+            arch: "aarch64"
+            runner: "ubuntu-24.04-arm"
+    runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
 
@@ -151,7 +190,7 @@ jobs:
       - name: Upload RPM
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: akr_${{ matrix.platform }}_x86_64.rpm
+          name: akr_${{ matrix.platform }}_${{ matrix.arch }}.rpm
           path: akr.rpm
 
   centos:
@@ -164,9 +203,21 @@ jobs:
         include:
           - image: "quay.io/centos/centos:stream9"
             platform: "centos9"
+            arch: "x86_64"
+            runner: "ubuntu-24.04"
+          - image: "quay.io/centos/centos:stream9"
+            platform: "centos9"
+            arch: "aarch64"
+            runner: "ubuntu-24.04-arm"
           - image: "quay.io/centos/centos:stream10"
             platform: "centos10"
-    runs-on: ubuntu-24.04
+            arch: "x86_64"
+            runner: "ubuntu-24.04"
+          - image: "quay.io/centos/centos:stream10"
+            platform: "centos10"
+            arch: "aarch64"
+            runner: "ubuntu-24.04-arm"
+    runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
 
@@ -214,5 +265,5 @@ jobs:
       - name: Upload RPM
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: akr_${{ matrix.platform }}_x86_64.rpm
+          name: akr_${{ matrix.platform }}_${{ matrix.arch }}.rpm
           path: akr.rpm

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -17,13 +17,31 @@ jobs:
         include:
           - image: "ubuntu:22.04"
             platform: "ubuntu22"
+            arch: "amd64"
+            runner: "ubuntu-24.04"
+          - image: "ubuntu:22.04"
+            platform: "ubuntu22"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
           - image: "ubuntu:24.04"
             platform: "ubuntu24"
+            arch: "amd64"
+            runner: "ubuntu-24.04"
+          - image: "ubuntu:24.04"
+            platform: "ubuntu24"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
           - image: "ubuntu:26.04"
             platform: "ubuntu26"
+            arch: "amd64"
+            runner: "ubuntu-24.04"
+          - image: "ubuntu:26.04"
+            platform: "ubuntu26"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
     permissions:
       contents: write
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
 
@@ -51,8 +69,9 @@ jobs:
       - name: Create package
         env:
           PLATFORM: ${{ matrix.platform }}
+          ARCH: ${{ matrix.arch }}
           VERSION: ${{ github.event.release.tag_name }}
-        run: cargo deb -p akr -o "akr_${VERSION}_${PLATFORM}_amd64.deb"
+        run: cargo deb -p akr -o "akr_${VERSION}_${PLATFORM}_${ARCH}.deb"
 
       - name: Verify package
         run: |
@@ -76,15 +95,36 @@ jobs:
           - image: "rockylinux/rockylinux:8"
             platform: "rhel8"
             repo: "powertools"
+            arch: "x86_64"
+            runner: "ubuntu-24.04"
+          - image: "rockylinux/rockylinux:8"
+            platform: "rhel8"
+            repo: "powertools"
+            arch: "aarch64"
+            runner: "ubuntu-24.04-arm"
           - image: "rockylinux/rockylinux:9"
             platform: "rhel9"
             repo: "crb"
+            arch: "x86_64"
+            runner: "ubuntu-24.04"
+          - image: "rockylinux/rockylinux:9"
+            platform: "rhel9"
+            repo: "crb"
+            arch: "aarch64"
+            runner: "ubuntu-24.04-arm"
           - image: "rockylinux/rockylinux:10"
             platform: "rhel10"
             repo: "crb"
+            arch: "x86_64"
+            runner: "ubuntu-24.04"
+          - image: "rockylinux/rockylinux:10"
+            platform: "rhel10"
+            repo: "crb"
+            arch: "aarch64"
+            runner: "ubuntu-24.04-arm"
     permissions:
       contents: write
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
 
@@ -146,10 +186,11 @@ jobs:
         shell: sh
         env:
           PLATFORM: ${{ matrix.platform }}
+          ARCH: ${{ matrix.arch }}
           VERSION: ${{ github.event.release.tag_name }}
         run: |
           . "$HOME/.cargo/env"
-          cargo generate-rpm -p crates/kr -o "akr_${VERSION}_${PLATFORM}_x86_64.rpm"
+          cargo generate-rpm -p crates/kr -o "akr_${VERSION}_${PLATFORM}_${ARCH}.rpm"
 
       - name: Verify package
         shell: sh
@@ -173,11 +214,23 @@ jobs:
         include:
           - image: "quay.io/centos/centos:stream9"
             platform: "centos9"
+            arch: "x86_64"
+            runner: "ubuntu-24.04"
+          - image: "quay.io/centos/centos:stream9"
+            platform: "centos9"
+            arch: "aarch64"
+            runner: "ubuntu-24.04-arm"
           - image: "quay.io/centos/centos:stream10"
             platform: "centos10"
+            arch: "x86_64"
+            runner: "ubuntu-24.04"
+          - image: "quay.io/centos/centos:stream10"
+            platform: "centos10"
+            arch: "aarch64"
+            runner: "ubuntu-24.04-arm"
     permissions:
       contents: write
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image }}
 
@@ -217,8 +270,9 @@ jobs:
       - name: Create package
         env:
           PLATFORM: ${{ matrix.platform }}
+          ARCH: ${{ matrix.arch }}
           VERSION: ${{ github.event.release.tag_name }}
-        run: cargo generate-rpm -p crates/kr -o "akr_${VERSION}_${PLATFORM}_x86_64.rpm"
+        run: cargo generate-rpm -p crates/kr -o "akr_${VERSION}_${PLATFORM}_${ARCH}.rpm"
 
       - name: Verify package
         run: |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Commands:
 
 ## Requirements
 
-- macOS (10.15+) or Linux (64 Bit) (Debian, RHEL, and CentOS).
+- macOS (Apple Silicon, 11+) or Linux (Debian, RHEL, and CentOS) on `x86_64` or `arm64`/`aarch64`.
 - OpenSSH Client and Server 8.2+
 - pinentry
 


### PR DESCRIPTION
Build deb/rpm packages for both x86_64 and arm64/aarch64 across Ubuntu 22/24/26, Rocky 8/9/10, and CentOS Stream 9/10 using ubuntu-24.04-arm runners. Brew bottles are now labeled with the proper arm64_* Homebrew codenames (arm64_big_sur through arm64_sequoia).